### PR TITLE
feat: upgrade terraform docs using renovate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
----
+- Update terraform docs docker image version using renovate.
 
-## [0.15.0] - 2024-14-11
+## [0.16.0] - 2024-11-25
+
+- Update module `terraform-google-gcp-application-bucket-creation-helper` to `0.9.0` with lifecycle policy for buckets.
+
+## [0.15.0] - 2024-11-14
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-cloud-native-drupal-resources/compare/0.14.0...0.15.0)
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TERRAFORM_DOCS_VERSION ?= 0.18.0
+
 .PHONY: lint tfscan generate-docs
 
 lint:
@@ -10,4 +12,13 @@ generate-docs: lint
 	docker run --rm -u $$(id -u) \
 		--volume "$(PWD):/terraform-docs" \
 		-w /terraform-docs \
-		quay.io/terraform-docs/terraform-docs:0.16.0 markdown table --config .terraform-docs.yml --output-file README.md --output-mode inject .
+		quay.io/terraform-docs/terraform-docs:$(TERRAFORM_DOCS_VERSION) markdown table --config .terraform-docs.yml --output-file README.md --output-mode inject .
+
+# Renovate configuration test
+renovate-test:
+	@docker run --rm -it \
+		-u "0:0" \
+		-e LOG_LEVEL=debug \
+		-v "$(PWD)":/tmp/app \
+		--entrypoint bash \
+		renovate/renovate -lc "cp -av /tmp/app /usr/src && cd /usr/src/app && jq 'del(.extends)' /tmp/app/renovate.json >/usr/src/app/renovate.json && renovate --platform=local --dry-run"

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
   namespace_list = [
     for p in var.drupal_projects_list : {
       namespace = p.kubernetes_namespace == null ? "${p.project_name}-${p.gitlab_project_id}-${p.release_branch_name}" : p.kubernetes_namespace
-      labels    = merge(
+      labels = merge(
         p.kubernetes_namespace_labels,
         var.default_k8s_labels
       )
@@ -74,7 +74,7 @@ module "drupal_databases_and_users" {
 # recovery enabled by default.
 module "drupal_buckets" {
   count                             = var.create_buckets == true ? 1 : 0
-  source                            = "github.com/sparkfabrik/terraform-google-gcp-application-bucket-creation-helper?ref=0.8.1"
+  source                            = "github.com/sparkfabrik/terraform-google-gcp-application-bucket-creation-helper?ref=0.9.0"
   project_id                        = var.project_id
   buckets_list                      = local.drupal_buckets_list
   logging_bucket_name               = var.logging_bucket_name
@@ -88,7 +88,7 @@ resource "kubernetes_namespace" "namespace" {
   }
 
   metadata {
-    name = each.value.namespace
+    name   = each.value.namespace
     labels = each.value.labels
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>sparkfabrik/renovatebot-default-configuration"
-  ]
+  "extends": ["github>sparkfabrik/renovatebot-default-configuration"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["Makefile"],
+      "matchStrings": ["TERRAFORM_DOCS_VERSION \\?= (?<currentValue>.*?)\n"],
+      "depNameTemplate": "terraform_docs_makefile",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.terraform_docs_makefile"
+    }
+  ],
+  "customDatasources": {
+    "terraform_docs_makefile": {
+      "defaultRegistryUrlTemplate": "https://quay.io/api/v1/repository/terraform-docs/terraform-docs/tag/",
+      "transformTemplates": [
+        "{ \"releases\": $map($.tags, function($v) { { \"version\": $v.name } }) }"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented automated version management for terraform-docs using Renovate:
  - Added version variable in Makefile for terraform-docs
  - Configured custom Renovate manager to track version in Makefile
  - Set up custom datasource to fetch versions from Quay.io repository
- Added renovate-test target in Makefile for configuration testing
- Updated CHANGELOG.md to reflect the automation changes



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with terraform-docs version upgrade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added entry about terraform docs docker image version update using <br>renovate<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-cloud-native-drupal-resources/pull/39/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add version variable and renovate test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>Added TERRAFORM_DOCS_VERSION variable with default value 0.16.0<br> <li> Updated terraform-docs docker command to use the version variable<br> <li> Added renovate-test target for testing renovate configuration<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-cloud-native-drupal-resources/pull/39/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+12/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Configure renovate for terraform-docs version management</code>&nbsp; </dd></summary>
<hr>

renovate.json

<li>Added custom manager for tracking terraform-docs version in Makefile<br> <li> Configured custom datasource for fetching terraform-docs versions from <br>Quay.io<br> <li> Added version transformation templates for proper version handling<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-cloud-native-drupal-resources/pull/39/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+19/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information