### PR TITLE
fix(secrets): unwrap password presence test to keep for_each non-sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-15
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-cloud-native-drupal-resources/compare/1.3.0...1.3.1)
+
 ### Fixed
 
 - Fix `kubernetes_secret.database_secret_name` failing to plan when `cloudsql_privileged_user_password` is set, because `map_of_drupal_databases` was marked sensitive and rejected as a `for_each` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `kubernetes_secret.database_secret_name` failing to plan when `cloudsql_privileged_user_password` is set, because `map_of_drupal_databases` was marked sensitive and rejected as a `for_each` argument.
+
 ## [1.3.0] - 2026-05-07
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-cloud-native-drupal-resources/compare/1.2.2...1.3.0)

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,8 @@
-/*
- *  Database, user and bucket list for Drupal projects. If not specified, the
- *  name of the database, user and bucket will be generated using the project
- *  name.
- *  Specifying a database name, user name or bucket name is suggested only when
- *  you want to import in Terraform or move in the module existing resources.
- */
+# Database, user and bucket list for Drupal projects. If not specified, the
+# name of the database, user and bucket will be generated using the project
+# name.
+# Specifying a database name, user name or bucket name is suggested only when
+# you want to import in Terraform or move in the module existing resources.
 
 locals {
   drupal_database_and_user_list = [

--- a/secrets.tf
+++ b/secrets.tf
@@ -2,7 +2,12 @@ locals {
   map_of_drupal_buckets = var.create_buckets == true ? {
     for o in local.drupal_buckets_list : o.name => o
   } : {}
-  map_of_drupal_databases = trimspace(var.cloudsql_instance_name) != "" && trimspace(var.cloudsql_privileged_user_name) != "" && trimspace(var.cloudsql_privileged_user_password) != "" && var.create_databases_and_users == true ? {
+  # nonsensitive() wraps only the password-presence test: it is a boolean that
+  # reveals nothing secret, but without unwrapping it would mark the whole map
+  # sensitive and for_each rejects sensitive values. The map values themselves
+  # keep their own marks, so a genuinely sensitive field added later re-triggers
+  # the for_each error instead of leaking silently.
+  map_of_drupal_databases = trimspace(var.cloudsql_instance_name) != "" && trimspace(var.cloudsql_privileged_user_name) != "" && nonsensitive(trimspace(var.cloudsql_privileged_user_password) != "") && var.create_databases_and_users == true ? {
     for o in local.drupal_database_and_user_list : o.database => o
   } : {}
   map_of_output_drupal_databases = trimspace(var.cloudsql_instance_name) != "" && trimspace(var.cloudsql_privileged_user_name) != "" && trimspace(var.cloudsql_privileged_user_password) != "" && var.create_databases_and_users == true ? {
@@ -23,10 +28,7 @@ locals {
 }
 
 resource "kubernetes_secret" "bucket_secret_name" {
-  for_each = {
-    for o in local.map_of_drupal_buckets : o.name => o
-    if var.create_buckets == true
-  }
+  for_each = local.map_of_drupal_buckets
 
   metadata {
     # If not specified, we suppose that the Helm release name is defined with
@@ -49,7 +51,7 @@ resource "kubernetes_secret" "bucket_secret_name" {
 resource "kubernetes_secret" "database_secret_name" {
   for_each = {
     for o in local.map_of_drupal_databases : o.database => o
-    if trimspace(o.namespace) != "" && var.create_databases_and_users == true
+    if trimspace(o.namespace) != ""
   }
   metadata {
     # If not specified, we suppose that the Helm release name is defined with

--- a/secrets.tf
+++ b/secrets.tf
@@ -2,11 +2,11 @@ locals {
   map_of_drupal_buckets = var.create_buckets == true ? {
     for o in local.drupal_buckets_list : o.name => o
   } : {}
-  # nonsensitive() wraps only the password-presence test: it is a boolean that
-  # reveals nothing secret, but without unwrapping it would mark the whole map
-  # sensitive and for_each rejects sensitive values. The map values themselves
-  # keep their own marks, so a genuinely sensitive field added later re-triggers
-  # the for_each error instead of leaking silently.
+  # nonsensitive() wraps only the password-presence test, a boolean that reveals
+  # nothing secret. Testing the sensitive cloudsql_privileged_user_password in the
+  # predicate otherwise marks the whole map sensitive, and for_each rejects
+  # sensitive collections. Unwrapping just this boolean is enough: the map values
+  # are built from the non-sensitive drupal_projects_list and carry no secret.
   map_of_drupal_databases = trimspace(var.cloudsql_instance_name) != "" && trimspace(var.cloudsql_privileged_user_name) != "" && nonsensitive(trimspace(var.cloudsql_privileged_user_password) != "") && var.create_databases_and_users == true ? {
     for o in local.drupal_database_and_user_list : o.database => o
   } : {}


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @filippolmt._

## What

The `map_of_drupal_databases` construction guard tests the sensitive `cloudsql_privileged_user_password`. In Terraform a conditional whose predicate is sensitive marks the whole result sensitive, so the map became sensitive and `kubernetes_secret.database_secret_name` failed with the "sensitive values cannot be used as for_each arguments" error.

This wraps only the boolean password-presence test in `nonsensitive()`, at the source (the `locals` guard), rather than blanket-unwrapping the whole map at the `for_each`. The password-presence test is a boolean that reveals nothing secret. The map values are built from the non-sensitive `drupal_projects_list` and carry no secret, so unwrapping just that boolean is sufficient.

## Changes

- `map_of_drupal_databases`: wrap the `cloudsql_privileged_user_password` presence test in `nonsensitive()`; the map is no longer sensitive.
- `database_secret_name` `for_each`: drop the `nonsensitive()` wrap (now unneeded) and the redundant `create_databases_and_users == true` filter already enforced by the map guard. The namespace filter is kept.
- `bucket_secret_name` `for_each`: collapse the identity re-key comprehension and redundant `create_buckets` filter to `local.map_of_drupal_buckets`.
- `map_of_output_drupal_databases` is left sensitive on purpose: its values carry the real password.
- `main.tf`: convert the top block comment to `#` lines to satisfy the tflint `terraform_comment_syntax` rule.
- CHANGELOG: add a Fixed entry under [Unreleased].

## Verification

`terraform fmt` is clean and `terraform validate` succeeds (only pre-existing provider deprecation warnings). The fix was also verified against a minimal isolated Terraform module: the original sensitive-`for_each` error reproduces without the wrap, the wrap resolves it, and a sensitive value placed inside the map stays redacted in the plan output.

## Refs

https://gitlab.sparkfabrik.com/sparkfabrik-innovation-team/board/-/work_items/3611